### PR TITLE
Add curl to request logs

### DIFF
--- a/src/main/java/vn/autobot/webhook/dto/RequestLogDto.java
+++ b/src/main/java/vn/autobot/webhook/dto/RequestLogDto.java
@@ -20,4 +20,4 @@ public class RequestLogDto {
     private LocalDateTime timestamp;
     private Integer responseStatus;
     private String responseBody;
-}
+    private String curl;}

--- a/src/main/java/vn/autobot/webhook/model/RequestLog.java
+++ b/src/main/java/vn/autobot/webhook/model/RequestLog.java
@@ -58,8 +58,12 @@ public class RequestLog {
     @Type(type = "org.hibernate.type.TextType")
     private String responseBody;
 
+    @Column(name = "curl")
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
+    private String curl;
+
     @PrePersist
     protected void onCreate() {
         this.timestamp = LocalDateTime.now();
-    }
-}
+    }}

--- a/src/main/java/vn/autobot/webhook/service/RequestLogService.java
+++ b/src/main/java/vn/autobot/webhook/service/RequestLogService.java
@@ -101,13 +101,13 @@ public class RequestLogService {
             while (headerNames.hasMoreElements()) {
                 String name = headerNames.nextElement();
                 String value = request.getHeader(name);
-                curl.append(" -H '\").append(name).append(": ").append(value).append("'\");
+                curl.append(" -H '").append(name).append(": ").append(value).append("'");
             }
         }
 
         if (body != null && !body.isEmpty()) {
             String escapedBody = body.replace("'", "'\\''");
-            curl.append(" -d '\").append(escapedBody).append("'\");
+            curl.append(" -d '").append(escapedBody).append("'");
         }
 
         String url = request.getRequestURL().toString();

--- a/src/main/java/vn/autobot/webhook/service/RequestLogService.java
+++ b/src/main/java/vn/autobot/webhook/service/RequestLogService.java
@@ -83,6 +83,7 @@ public class RequestLogService {
         requestLog.setRequestBody(body);
         requestLog.setResponseStatus(status);
         requestLog.setResponseBody(responseBody);
+        requestLog.setCurl(buildCurl(request, body));
 
         RequestLog savedLog = requestLogRepository.save(requestLog);
 
@@ -90,6 +91,32 @@ public class RequestLogService {
         webSocketService.sendRequestUpdate(user.getUsername());
 
         return savedLog;
+    }
+
+    private String buildCurl(HttpServletRequest request, String body) {
+        StringBuilder curl = new StringBuilder("curl -X ").append(request.getMethod());
+
+        Enumeration<String> headerNames = request.getHeaderNames();
+        if (headerNames != null) {
+            while (headerNames.hasMoreElements()) {
+                String name = headerNames.nextElement();
+                String value = request.getHeader(name);
+                curl.append(" -H '\").append(name).append(": ").append(value).append("'\");
+            }
+        }
+
+        if (body != null && !body.isEmpty()) {
+            String escapedBody = body.replace("'", "'\\''");
+            curl.append(" -d '\").append(escapedBody).append("'\");
+        }
+
+        String url = request.getRequestURL().toString();
+        if (request.getQueryString() != null && !request.getQueryString().isEmpty()) {
+            url += "?" + request.getQueryString();
+        }
+        curl.append(" '").append(url).append("'");
+
+        return curl.toString();
     }
 
     public Page<RequestLogDto> getRequestLogs(String username, Pageable pageable) {
@@ -124,7 +151,7 @@ public class RequestLogService {
             Row headerRow = sheet.createRow(0);
             String[] columns = {"ID", "Method", "Path", "Source IP", "Query Params",
                     "Request Headers", "Request Body", "Timestamp",
-                    "Response Status", "Response Body"};
+                    "Response Status", "Response Body", "Curl"};
 
             // Create header cell style
             CellStyle headerCellStyle = workbook.createCellStyle();
@@ -153,6 +180,7 @@ public class RequestLogService {
                 row.createCell(7).setCellValue(log.getTimestamp() != null ? log.getTimestamp().format(formatter) : "");
                 row.createCell(8).setCellValue(log.getResponseStatus() != null ? log.getResponseStatus() : 0);
                 row.createCell(9).setCellValue(log.getResponseBody() != null ? log.getResponseBody() : "");
+                row.createCell(10).setCellValue(log.getCurl() != null ? log.getCurl() : "");
             }
 
             // Auto size columns
@@ -183,6 +211,6 @@ public class RequestLogService {
         dto.setTimestamp(requestLog.getTimestamp());
         dto.setResponseStatus(requestLog.getResponseStatus());
         dto.setResponseBody(requestLog.getResponseBody());
+        dto.setCurl(requestLog.getCurl());
         return dto;
-    }
-}
+    }}

--- a/src/main/resources/templates/request-logs.html
+++ b/src/main/resources/templates/request-logs.html
@@ -155,6 +155,12 @@
                                                         Response
                                                     </button>
                                                 </li>
+                                                <li class="nav-item" role="presentation">
+                                                    <button class="nav-link" th:id="'curl-tab' + ${log.id}" data-bs-toggle="tab"
+                                                            th:data-bs-target="'#curl' + ${log.id}" type="button" role="tab">
+                                                        Curl
+                                                    </button>
+                                                </li>
                                             </ul>
                                             <div class="tab-content mt-3" th:id="'logTabContent' + ${log.id}">
                                                 <!-- Overview Tab -->
@@ -224,6 +230,16 @@
                                                                 </pre>
                                                         <div th:if="${log.responseBody == null || log.responseBody == ''}"
                                                              class="text-muted">No response body available</div>
+                                                    </div>
+                                                </div>
+                                                <!-- Curl Tab -->
+                                                <div class="tab-pane fade" th:id="'curl' + ${log.id}" role="tabpanel">
+                                                    <div class="log-details">
+                                                                <pre th:if="${log.curl != null && log.curl != ''}"
+                                                                     th:text="${log.curl}">
+                                                                </pre>
+                                                        <div th:if="${log.curl == null || log.curl == ''}"
+                                                             class="text-muted">No curl available</div>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
## Summary
- track a generated curl command on each logged request
- include curl data in request log DTO and Excel export
- display curl on the request details modal

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_686df2ca054c8326b22d677402f79063