### PR TITLE
Add curl copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ WebHookMock is a Spring Boot application designed to simplify webhook developmen
 - Set response content types (JSON, XML, HTML, etc.)
 - Customize response headers
 - Add response delays to simulate latency
+- Dynamic response templates with request variables (e.g. `{{headers.User-Agent}}`)
 
 ### 📡 Request Monitoring
 
@@ -30,6 +31,8 @@ WebHookMock is a Spring Boot application designed to simplify webhook developmen
 - Detailed view of request headers, body, and parameters
 - WebSocket support for live updates
 - Export logs to Excel for further analysis
+- Each log entry includes a ready-to-use `curl` command
+- REST endpoints documented in `static/swagger.json`
 
 ### 🔐 User Management
 
@@ -124,6 +127,7 @@ Default URL: `http://localhost:8081`
 ### Configuration
 
 The application uses an H2 database by default, with the database file stored in the `./data/mockwebhook` directory. You can modify the configuration in `application.properties`.
+You can set the base domain for generated webhook URLs via `app.domain` or the `APP_DOMAIN` environment variable. The H2 console is available at `/h2-console` during development.
 
 ## Usage
 

--- a/src/main/resources/static/js/request-log.js
+++ b/src/main/resources/static/js/request-log.js
@@ -125,4 +125,23 @@ document.addEventListener('DOMContentLoaded', function() {
                 console.error('Error fetching log count:', error);
             });
     }, 2000);
+    // Copy curl command functionality
+    const curlButtons = document.querySelectorAll('.copy-curl-btn');
+    if (curlButtons.length > 0) {
+        const toastEl = document.getElementById('copyCurlToast');
+        const toast = new bootstrap.Toast(toastEl, { delay: 2000 });
+        const toastMsg = document.getElementById('copyCurlToastMessage');
+
+        curlButtons.forEach(btn => {
+            btn.addEventListener('click', function() {
+                const curl = this.getAttribute('data-curl');
+                navigator.clipboard.writeText(curl)
+                    .then(() => {
+                        toastMsg.textContent = 'Curl copied to clipboard!';
+                        toast.show();
+                    })
+                    .catch(err => console.error('Failed to copy curl:', err));
+            });
+        });
+    }
 });

--- a/src/main/resources/templates/request-logs.html
+++ b/src/main/resources/templates/request-logs.html
@@ -238,6 +238,11 @@
                                                                 <pre th:if="${log.curl != null && log.curl != ''}"
                                                                      th:text="${log.curl}">
                                                                 </pre>
+                                                        <button class="btn btn-sm btn-outline-secondary mt-2 copy-curl-btn"
+                                                                th:if="${log.curl != null && log.curl != ''}"
+                                                                th:data-curl="${log.curl}">
+                                                            <i class="fas fa-copy"></i> Copy
+                                                        </button>
                                                         <div th:if="${log.curl == null || log.curl == ''}"
                                                              class="text-muted">No curl available</div>
                                                     </div>
@@ -351,6 +356,18 @@
 
 <div th:replace="fragments/footer :: footer"></div>
 
+<!-- Copy Curl Toast -->
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1050">
+    <div id="copyCurlToast" class="toast align-items-center text-white bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="d-flex">
+            <div class="toast-body">
+                <i class="fas fa-check-circle me-2"></i> <span id="copyCurlToastMessage">Curl copied to clipboard!</span>
+            </div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+    </div>
+</div>
+
 <script th:inline="javascript">
     /*<![CDATA[*/
     const username = /*[[${targetUsername}]]*/;
@@ -365,5 +382,4 @@
         window.location.href = `/view/@${username}?page=0&size=${selectedSize}`;
     });
 </script>
-</body>
-</html>
+</body></html>


### PR DESCRIPTION
## Summary
- add Copy button on Curl tab for request logs
- show toast when curl command is copied to clipboard

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/..)*

------
https://chatgpt.com/codex/tasks/task_e_686e06cc3cec8326831b817c838a9a27