### PR TITLE
Add admin role and management UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/vn/autobot/webhook/config/SecurityConfig.java
+++ b/src/main/java/vn/autobot/webhook/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
                 .antMatchers("/api/**").permitAll() // Allow all webhook API requests
                 .antMatchers("/register", "/login", "/css/**", "/js/**", "/swagger.json", "/swagger-ui", "/swagger-ui/**", "/swagger/**", "/h2-console/**").permitAll()
+                .antMatchers("/admin/**").hasAuthority("ADMIN")
                 .anyRequest().authenticated()
                 .and()
             .formLogin()
@@ -48,3 +49,4 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }}
+

--- a/src/main/java/vn/autobot/webhook/config/UserDetailsServiceImpl.java
+++ b/src/main/java/vn/autobot/webhook/config/UserDetailsServiceImpl.java
@@ -25,7 +25,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         return new org.springframework.security.core.userdetails.User(
                 user.getUsername(),
                 user.getPassword(),
-                Collections.singletonList(new SimpleGrantedAuthority("USER"))
+                Collections.singletonList(new SimpleGrantedAuthority(user.getRole()))
         );
     }
 }

--- a/src/main/java/vn/autobot/webhook/controller/AdminController.java
+++ b/src/main/java/vn/autobot/webhook/controller/AdminController.java
@@ -1,0 +1,36 @@
+package vn.autobot.webhook.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import vn.autobot.webhook.model.User;
+import vn.autobot.webhook.service.UserService;
+
+@Controller
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+
+    @GetMapping("/users")
+    public String listUsers(Model model) {
+        model.addAttribute("users", userService.findAllUsers());
+        return "admin/users";
+    }
+
+    @GetMapping("/users/{id}")
+    public String viewUser(@PathVariable Long id, Model model) {
+        User user = userService.findById(id);
+        model.addAttribute("user", user);
+        return "admin/user-view";
+    }
+
+    @PostMapping("/users/{id}/delete")
+    public String deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return "redirect:/admin/users";
+    }
+}
+

--- a/src/main/java/vn/autobot/webhook/model/User.java
+++ b/src/main/java/vn/autobot/webhook/model/User.java
@@ -29,6 +29,9 @@ public class User {
     @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
+    private String role;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
@@ -38,5 +41,9 @@ public class User {
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
+        if (this.role == null) {
+            this.role = "USER";
+        }
     }
 }
+

--- a/src/main/java/vn/autobot/webhook/repository/UserRepository.java
+++ b/src/main/java/vn/autobot/webhook/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     boolean existsByEmail(String email);
+
+    java.util.List<User> findByRole(String role);
 }

--- a/src/main/java/vn/autobot/webhook/service/UserService.java
+++ b/src/main/java/vn/autobot/webhook/service/UserService.java
@@ -33,6 +33,7 @@ public class UserService {
         user.setUsername(registerRequest.getUsername());
         user.setEmail(registerRequest.getEmail());
         user.setPassword(passwordEncoder.encode(registerRequest.getPassword()));
+        user.setRole("USER");
 
         return userRepository.save(user);
     }
@@ -45,4 +46,18 @@ public class UserService {
     public boolean existsByUsername(String username) {
         return userRepository.existsByUsername(username);
     }
+
+    public java.util.List<User> findAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    public void deleteUser(Long id) {
+        userRepository.deleteById(id);
+    }
 }
+

--- a/src/main/resources/templates/admin/user-view.html
+++ b/src/main/resources/templates/admin/user-view.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head th:replace="fragments/header :: head('User Details')">
+    <title>User Details</title>
+</head>
+<body>
+<div th:replace="fragments/header :: header"></div>
+<div class="container">
+    <div th:replace="fragments/navigation :: navigation"></div>
+    <h2 class="mb-4">User Details</h2>
+    <dl class="row">
+        <dt class="col-sm-3">ID</dt>
+        <dd class="col-sm-9" th:text="${user.id}"></dd>
+        <dt class="col-sm-3">Username</dt>
+        <dd class="col-sm-9" th:text="${user.username}"></dd>
+        <dt class="col-sm-3">Email</dt>
+        <dd class="col-sm-9" th:text="${user.email}"></dd>
+        <dt class="col-sm-3">Role</dt>
+        <dd class="col-sm-9" th:text="${user.role}"></dd>
+    </dl>
+    <a href="/admin/users" class="btn btn-secondary">Back</a>
+    <form th:action="@{|/admin/users/${user.id}/delete|}" method="post" style="display:inline" class="ms-1">
+        <button class="btn btn-danger" type="submit" onclick="return confirm('Delete this user?')">Delete</button>
+    </form>
+</div>
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>
+

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head th:replace="fragments/header :: head('User Management')">
+    <title>User Management</title>
+</head>
+<body>
+<div th:replace="fragments/header :: header"></div>
+<div class="container">
+    <div th:replace="fragments/navigation :: navigation"></div>
+    <h2 class="mb-4">All Users</h2>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Username</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="user : ${users}">
+            <td th:text="${user.id}"></td>
+            <td th:text="${user.username}"></td>
+            <td th:text="${user.email}"></td>
+            <td th:text="${user.role}"></td>
+            <td>
+                <a th:href="@{|/admin/users/${user.id}|}" class="btn btn-sm btn-primary">View</a>
+                <form th:action="@{|/admin/users/${user.id}/delete|}" method="post" style="display:inline" class="ms-1">
+                    <button class="btn btn-sm btn-danger" type="submit" onclick="return confirm('Delete this user?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>
+

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
   <head th:fragment="head(title)">
     <!-- SEO Meta Tags -->
@@ -61,6 +61,7 @@
                 <li><a class="dropdown-item" th:href="@{|/view/@${username}|}"><i class="fas fa-history me-1"></i> Request Logs</a></li>
                 <li><a class="dropdown-item" th:href="@{|/swagger/@${username}|}" target="_blank"><i class="fas fa-book me-1"></i>
                     Swagger</a></li>
+                <li sec:authorize="hasAuthority('ADMIN')"><a class="dropdown-item" th:href="@{/admin/users}"><i class="fas fa-user-cog me-1"></i> Admin</a></li>
                 <li>
                   <hr class="dropdown-divider">
                 </li>

--- a/src/main/resources/templates/fragments/navigation.html
+++ b/src/main/resources/templates/fragments/navigation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
   <body>
     <div th:fragment="navigation" class="bg-light p-3 mb-4 rounded">
@@ -16,6 +16,11 @@
           th:classappend="${#httpServletRequest.getRequestURI().startsWith('/view/@' + username) ? 'active' : ''}"
           th:href="@{|/view/@${username}|}">
           <i class="fas fa-history me-1"></i> Request Logs
+        </a>
+        <a class="flex-sm-fill text-sm-center nav-link" sec:authorize="hasAuthority('ADMIN')"
+          th:classappend="${#httpServletRequest.getRequestURI().startsWith('/admin') ? 'active' : ''}"
+          th:href="@{/admin/users}">
+          <i class="fas fa-user-cog me-1"></i> Admin
         </a>
       </nav>
     </div>

--- a/src/test/java/vn/autobot/webhook/controller/AdminControllerTest.java
+++ b/src/test/java/vn/autobot/webhook/controller/AdminControllerTest.java
@@ -1,0 +1,34 @@
+package vn.autobot.webhook.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "admin", authorities = {"ADMIN"})
+    void adminAccessAllowed() throws Exception {
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "user", authorities = {"USER"})
+    void adminAccessForbiddenForUser() throws Exception {
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isForbidden());
+    }
+}
+


### PR DESCRIPTION
## Summary
- support user roles with a new `role` field
- query users by role in `UserRepository`
- include authorities from role in `UserDetailsServiceImpl`
- restrict `/admin/**` paths to admins only
- add basic admin controller and templates for user management
- show admin navigation links when appropriate
- provide tests for admin security

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68747a72c6448326afa335dc7324ff31